### PR TITLE
Sprachliche Korrekturen

### DIFF
--- a/docs/lernberichte/hpc/ssl/lb10.md
+++ b/docs/lernberichte/hpc/ssl/lb10.md
@@ -1,10 +1,10 @@
-In den letzten Wochen habe ich mich mit der SSL-Verschlüsselung auseinandergesetzt. Der Auftrag dazu war es WordPress mit SSL-Zertifikat zu verschlüsseln. Da ein Offizielles Zertifikat kostet, musste ich ein Selbst Signiertes SSL Zertifikat (Self-Signed SSL Certificates) erstellen. Hier noch meine Anleitung:
+In den letzten Wochen habe ich mich mit der SSL-Verschlüsselung auseinandergesetzt. Hierzu war der Auftrag gegen, die Kommunikation mit meinem WordPress-Server mit SSL-Zertifikat zu verschlüsseln. Da ein offizielles Zertifikat kostet, musste ich ein selbst-signiertes SSL Zertifikat (Self-Signed SS L Certificates) erstellen. Hier noch meine Anleitung:
 
 1. OpenSSL installieren
 
         sudo dnf install openssl -y
 
-2. SSL Modul installieren
+2. SSL-Modul für den Apache Webserver installieren
 
         sudo dnf install mod_ssl -y
 
@@ -20,7 +20,7 @@ In den letzten Wochen habe ich mich mit der SSL-Verschlüsselung auseinandergese
 
         sudo openssl req -key private.key -new -out server.csr
 
-    6. Die gefragten Angaben beantworten, einiges kann auch frei gelassen werden.
+6. Die gefragten Angaben beantworten, einiges kann auch frei gelassen werden.
 
 7. Aus der private**.key** und der server**.csr** die server**.crt** Datei generieren
 
@@ -38,7 +38,7 @@ In den letzten Wochen habe ich mich mit der SSL-Verschlüsselung auseinandergese
 
         sudo vi ssl.conf 
 
-    Datei anpassen:
+    Folgende Direktiven sind hierbei anzupassen:
 
     - DocumentRoot
     - ServerName
@@ -64,7 +64,7 @@ In den letzten Wochen habe ich mich mit der SSL-Verschlüsselung auseinandergese
         ...
 
         SSLCertificateKeyFile /etc/pki/tls/private/localhost.key
-        
+
         ...
 
 

--- a/docs/tagesberichte/2023/januar/tb11.md
+++ b/docs/tagesberichte/2023/januar/tb11.md
@@ -1,15 +1,15 @@
-## Tagesbericht 
+## Tagesbericht
 
 
 ### Tagesablauf
-Heute habe ich zuerst einen Pull-Request vom Michaels Rebositorie auf meinen Git-Rebositorie gemercht. Dabei ging es um die Korrekturen von meine Berichten. Danach habe ich noch einige Administrative Dinge erledigt. Vormittag hatte ich auch noch den wöchentlichen Gespräch mit Birgit. Dann habe ich noch mit dem neuen Auftrag von Michael begonnen. Bei dieser Auftrag ging es darum Wordpress mit SSl zu verschlüsseln. Am Nachmittag habe ich noch für den morgigen Quartalsbesprechung vorbereitet sowie am Auftrag weitergefahren.  
+Heute habe ich zuerst einen Pull-Request vom Michaels Repository auf meinen Git-Rebositorie übertragen. Dabei ging es um die Korrekturen von meine Berichten. Danach habe ich noch einige administrative Dinge erledigt. Vormittags hatte ich auch noch den wöchentlichen Gespräch mit Birgit. Dann habe ich noch mit dem neuen Auftrag von Michael begonnen. Bei diesem Auftrag ging es darum, die Komunikation zwischen einem Browser und meinem Wordpress-Server mittels SSL-Zertifikat zu verschlüsseln. Am Nachmittag habe ich mich noch für die morgigen Quartalsbesprechung vorbereitet, sowie am Auftrag weitergearbeitet.  
 
 ### Hilfestellung
-Bei Fragen konnte ich mich an das HPC-Team wenden. 
+Bei Fragen konnte ich mich an das HPC-Team wenden.
 
 ### Reflexion
-Ich habe bei einer Anleitung, welches ich im Internet fand, falsch verstanden, weshalb ich nicht mehr per localhost auf wordpress zugreifen konnte. Durch die Hilfe von Mattias kam ich dann weiter, dennoch funktioniert es immer noch nicht so wie es sollte.  
+Ich habe bei einer Anleitung, welche ich im Internet gefunden habe, falsch verstanden, weshalb ich nicht mehr per localhost auf Wordpress zugreifen konnte. Durch die Hilfe von Matthias kam ich dann weiter, dennoch funktioniert es immer noch nicht so wie es sollte.
 
-### Nächste Schritte 
+### Nächste Schritte
 Problem mit SSL lösen
 

--- a/docs/tagesberichte/2023/januar/tb12.md
+++ b/docs/tagesberichte/2023/januar/tb12.md
@@ -1,15 +1,15 @@
-## Tagesbericht 
+## Tagesbericht
 
 
 ### Tagesablauf
-Heute habe ich an der Verschlüsslung der Webseite gearbeitet. Danach hatte ich noch kurz ein Gespräch mit Michael über den aktuellen Stand, sowie einige Verbesserungen. Da ich am Nachmittag um 13:45 noch einen Vortrag hatte, habe ich mich darauf vorbereitet und dazu einen PowerPoint Präsentation erstellt. Nach der Präsentation fand noch die Quartalsbesprechung statt. Danach hat mir Michael noch die GitHub Pull Request erklärt, welche Vorteile ISSUES haben.  
+Heute habe ich an der Verschlüsselung der Webseite gearbeitet. Danach hatte ich noch ein kurzes Gespräch mit Michael über den aktuellen Stand, sowie einige Verbesserungen. Da ich am Nachmittag um 13:45 noch einen Vortrag hatte, habe ich mich auf diesen vorbereitet und dazu einen PowerPoint-Präsentation erstellt. Nach der Präsentation fand die Quartalsbesprechung statt. Danach hat mir Michael noch Pull Request auf GitHub erklärt und welche Vorteile Issues haben.  
 
 ### Hilfestellung
 Bei Fragen konnte ich mich an Michael wenden.
 
 ### Reflexion
-Ich konnte eine gute Präsentation halten, dennoch einige Fachfragen nicht beantworten. Auch die Quartalsbesprechung lief gut. 
+Ich konnte eine gute Präsentation halten, dennoch einige Fachfragen nicht beantworten. Auch die Quartalsbesprechung lief gut.
 
-### Nächste Schritte 
+### Nächste Schritte
 Wordpress mit SSL verschlüsseln
 

--- a/docs/tagesberichte/2023/januar/tb13.md
+++ b/docs/tagesberichte/2023/januar/tb13.md
@@ -1,15 +1,15 @@
-## Tagesbericht 
+## Tagesbericht
 
 
 ### Tagesablauf
-Heute habe ich weiter an der SSL Verschlüsselung gearbeitet. Dabei habe ich zuerst den Datenbank auf der Datenbankserver gelöscht und diesen neu erstellt. Danach ging ich noch den Poolrundgang machen. Dazu musste ich drei Räume kontrollieren und zwar den Jura-Pool, Tobler-Pool und zuletzt den FBB-Poolraum. Am Nachmittag war ich dann im Servicedesk. Dort konnte ich vor allem einige Anrufe beantworten sowie 1-Level-Support leisten. 
+Heute habe ich weiter an der SSL Verschlüsselung gearbeitet. Dabei habe ich zuerst den Datenbank auf der Datenbankserver gelöscht und diese neu erstellt. Danach ging ich noch auf den Poolrundgang. Dazu musste ich drei Räume kontrollieren und zwar den Jura-Pool, Tobler-Pool und zuletzt den FBB-Poolraum. Am Nachmittag war ich dann im Servicedesk. Dort konnte ich vor allem einige Anrufe beantworten sowie First-Level-Support leisten.
 
 ### Hilfestellung
-Bei Fragen konnte ich mich an Mattias wenden und ich Servicedesk stand mit das Servicedesk Team zur Hilfe. 
+Bei Fragen konnte ich mich an Matthias wenden und ich Servicedesk stand mit das Servicedesk Team zur Hilfe.
 
 ### Reflexion
 Ich konnte die Pool-Kontrolle erfolgreich abschliessen. Auch das Arbeiten im Servicedesk lief gut. Dennoch konnte ich nicht den WordPress erfolgreich mit SSL verschlüsseln.
 
-### Nächste Schritte 
+### Nächste Schritte
 WordPress mit SSL verschlüsseln
 

--- a/docs/tagesberichte/2023/januar/tb14.md
+++ b/docs/tagesberichte/2023/januar/tb14.md
@@ -2,13 +2,13 @@
 
 
 ### Tagesablauf
-Heute war ich weiterhin am Wordpress Problem dran, da dies immer noch funktionierte und deswegen konnte ich nicht die WordPress-Seite abrufen. Dazu habe ich zuerst einen Neuen Datenbank erstellt, damit die gesetzten Einstellungen wegfallen, dennoch funktionierte es nicht. Danach habe ich WordPress neu installiert, wwelches auch nicht half. Später habe ich dann mit dem Befehl "vagrant destroy" die beide Server entfernt und neu erstellt, da ich auch noch die aufgeschriebenen Befehle überprüfen musste. Danach habe ich noch WordPress mit SSL verschlüsselt. Am Morgen fand auch noch unser wöchentliches Gespräch statt und am Nachmittag fand noch die Besprechung zur Planung vom Schnuppertag statt.
+Heute war ich weiterhin am Wordpress-Problem dran, da dies immer noch funktionierte und deswegen konnte ich nicht die WordPress-Seite abrufen. Dazu habe ich zuerst einen neue Datenbank erstellt, damit die gesetzten Einstellungen wegfallen, dennoch funktionierte es nicht. Danach habe ich WordPress neu installiert, was auch nicht half. Später habe ich dann mit dem Befehl "vagrant destroy" die beiden Server entfernt und neu erstellt, da ich auch noch die aufgeschriebenen Befehle überprüfen musste. Danach habe ich noch WordPress mit SSL verschlüsselt. Am Morgen fand auch noch unser wöchentliches Gespräch statt und am Nachmittag fand noch die Besprechung zur Planung vom Schnuppertag statt.
 
 ### Hilfestellung
 Bei Fragen konnte ich mich an das HPC-Team sowie an Michael wenden.
 
 ### Reflexion
-Grösstenteils lief der Tag gut, wie z.B. das Wochengespräch, Schnuppertag Besprechung und das Erstellen der Servers. Dennoch konnte ich die WorPress-Seite nach dem Erstellen der Servers nicht abrufen. Dann habe ich mit Michael noch dies Besprochen und als wir dann auf der Suche nach dem Problem waren, fand ich bei dem Befehl "ifconfig" heraus, das der WEB-Server keine IP-Adresse zugewiessen bekam. Als ich dann im Vagrantfile nachsah, sah ich, dass die Zeile mit der IP-Zuweissung aus kommentiert war. Nach dem ich die Kommentierung herausnahm und den Server neu statete, funktionierte es dann und ich konnte die WordPress-Seite mit SSL-Verschlüsslung abrufen.
+Grösstenteils lief der Tag gut, wie z.B. das Wochengespräch, Schnuppertag Besprechung und das Erstellen der Servers. Dennoch konnte ich die WorPress-Seite nach dem Erstellen der Servers nicht abrufen. Dann habe ich das Problem mit Michael besprochen und als wir dann auf der Suche nach dem Problem waren, fand ich bei dem Befehl "ifconfig" heraus, das der WEB-Server keine IP-Adresse zugewiessen bekam. Als ich dann im Vagrantfile nachsah, sah ich, dass die Zeile mit der IP-Zuweisung auskommentiert war. Nachdem ich die Kommentierung herausgenommen hatte und den Server neugestartet hatte, funktionierte es dann und ich konnte die WordPress-Seite mit SSL-Verschlüsslung abrufen.
 
 ### Nächste Schritte 
 Dokumentieren

--- a/docs/tagesberichte/2023/januar/tb15.md
+++ b/docs/tagesberichte/2023/januar/tb15.md
@@ -1,15 +1,15 @@
-## Tagesbericht 
+## Tagesbericht
 
 
 ### Tagesablauf
-Heute Morgen habe ich zuerst mit der Dokumentation begonnen. Dabei habe ich dokumentiert, was SSL ist und auch die Installation davon. Danach habe ich mit dem Skript weitergefahren, welches benötigt wird, um die Servers mit dem Befehl "Vagrant up" komplett bereitzustellen. Am Nachmittag hatte ich noch den Velo Dienst und etwas später fand auch das Gespräch mit Stephan, Hanspeter und mit Dominic statt. Dabei ging es um eine kurze Einführung in die Gruppe Netzwerk. Gegen ende des Tages konnte ich noch mit Birgit einen Raum für den Schnuppertag reservieren.  
+Heute Morgen habe ich zuerst mit der Dokumentation begonnen. Dabei habe ich dokumentiert, was SSL ist und auch die Installation davon und wie selbst-signierte Zertifikate zu erzeugen sind. Danach habe ich mit dem Skript weitergefahren, welches benötigt wird, um die Server mit dem Befehl `vagrant up` komplett bereitzustellen. Am Nachmittag hatte ich noch den Velo-Dienst und etwas später fand auch das Gespräch mit Stephan, Hanspeter und mit Dominic statt. Dabei ging es um eine kurze Einführung in die Gruppe Netzwerk. Gegen Ende des Tages konnte ich noch mit Birgit einen Raum für den Schnuppertag reservieren.
 
 ### Hilfestellung
-Bei Fragen konnte ich mich an Michael oder auch an Mattias wenden.
+Bei Fragen konnte ich mich an Michael oder auch an Matthias wenden.
 
 ### Reflexion
-Der Velo Dienst, Gespräch mit der Netzwerk Gruppe sowie das reservieren vom Raum lief gut, auch die Dokumentationen konnte ich grösstenteils abschliessen. Aber der Skript läuft noch nicht ganz.
+Der Velo-Dienst, Gespräch mit der Netzwerk Gruppe sowie das reservieren vom Raum lief gut, auch die Dokumentationen konnte ich grösstenteils abschliessen. Aber der Skript läuft noch nicht ganz.
 
-### Nächste Schritte 
+### Nächste Schritte
 Skript fertig bringen.
 


### PR DESCRIPTION
Voila, die sprachlichen Korrekturen deiner Berichte.

Im Lernbericht 9 über SSL merkt man deutlich, dass praktisch alle Sätze
mittels Copy&Paste in den Bericht geflossen sind, womit sich die Eigenleistung
primär auf die Recherche beschränkt. Das ist für mich schon in Ordnung, aber für
mich muss die Quelle ebenfalls angegeben werden. Ich rate dir daher, diese Quellen
im Dokument auch zu nennen. So findest du später die (ausführlicheren) Anleitung
und Artikel wieder, aus denen du gelernt hast und kannst sie erneut besuchen.
Quellenangaben sind aus meiner Sicht wichtig und es muss auch nicht ersichtlich
sein, von welcher Seite welcher Satz kommt. Mach einfach ganz unten am Scnluyss
eine Liste mit Links zu den wichtigen Artikeln, aus denen der Lernbericht
entstanden ist.

Darüber hinaus hätte ich mir gewünscht, dass du die drei wesentlichen Dateien
rund um ein Zertifikat - `.key`, `.csr`, `.crt` - noch erwähnst und deren Rolle
beschreibst. Das gehört zum Basiswissen über Zertifiate.  
Bonusfrage: Sind diese Dateiendung wichtig?
